### PR TITLE
Remove Dockerfile reference to removed setup.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,6 @@ RUN chmod +x        /etc/service/mysql/run
 RUN mkdir -p        /var/lib/mysql/
 RUN chmod -R 755    /var/lib/mysql/
 
-ADD build/setup.sh  /etc/mysql/mysql_setup.sh
-RUN chmod +x        /etc/mysql/mysql_setup.sh
-
 ADD etc/my_init.d/99_mysql_setup.sh /etc/my_init.d/99_mysql_setup.sh
 RUN chmod +x /etc/my_init.d/99_mysql_setup.sh
 


### PR DESCRIPTION
Looks like it was missed from https://github.com/fideloper/docker-mysql/pull/4
