### PR TITLE
Add environment settings

### DIFF
--- a/build/mysql.sh
+++ b/build/mysql.sh
@@ -1,4 +1,39 @@
 #!/bin/bash
+set -e
+
+chown -R mysql:mysql /var/lib/mysql
+mysql_install_db --user mysql > /dev/null
+
+MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-""}
+MYSQL_DATABASE=${MYSQL_DATABASE:-""}
+MYSQL_USER=${MYSQL_USER:-""}
+MYSQL_PASSWORD=${MYSQL_PASSWORD:-""}
+MYSQLD_ARGS=${MYSQLD_ARGS:-""}
+
+tfile=`mktemp`
+if [[ ! -f "$tfile" ]]; then
+    return 1
+fi
+
+cat << EOF > $tfile
+USE mysql;
+FLUSH PRIVILEGES;
+GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;
+UPDATE user SET password=PASSWORD("$MYSQL_ROOT_PASSWORD") WHERE user='root';
+EOF
+
+if [[ $MYSQL_DATABASE != "" ]]; then
+    echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` CHARACTER SET utf8 COLLATE utf8_general_ci;" >> $tfile
+
+    if [[ $MYSQL_USER != "" ]]; then
+        echo "GRANT ALL ON \`$MYSQL_DATABASE\`.* to '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD';" >> $tfile
+    fi
+fi
+
+/usr/sbin/mysqld --bootstrap --verbose=0 $MYSQLD_ARGS < $tfile
+rm -f $tfile
+
+exec /usr/sbin/mysqld $MYSQLD_ARGS
 
 trap 'mysqladmin -u root -proot shutdown' EXIT
 


### PR DESCRIPTION
Now we can create user / database / password using docker environment variables.

docker run -p 3306:3306 --name mysql --env MYSQL_ROOT_PASSWORD=xehVg1IpVhEmlwRMG -d mysql /sbin/my_init --enable-insecure-key

inspired by https://github.com/orchardup/docker-mysql
