### PR TITLE
Change policy to enable service restart.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ CMD ["/sbin/my_init"]
 # Some Environment Variables
 ENV    DEBIAN_FRONTEND noninteractive
 
+RUN sed -i "s/^exit 101$/exit 0/" /usr/sbin/policy-rc.d
+
 # MySQL Installation
 RUN apt-get update
 RUN echo "mysql-server mysql-server/root_password password root" | debconf-set-selections

--- a/build/my.cnf
+++ b/build/my.cnf
@@ -44,7 +44,7 @@ skip-external-locking
 #
 # Instead of skip-networking the default is now to listen only on
 # localhost which is more compatible and is not less secure.
-bind-address       = 0.0.0.0
+# bind-address       = 0.0.0.0
 #
 # * Fine Tuning
 #


### PR DESCRIPTION
Fix problem when trying to restart any services in docker. 
>invoke-rc.d: policy-rc.d denied execution of stop.
>invoke-rc.d: policy-rc.d denied execution of start.